### PR TITLE
Add vmemo-proto Voice Memos automation prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 elia.sqlite
 **/*.pyc
 resources/conversations.json
+vmemo-proto.zip

--- a/vmemo-proto/README.md
+++ b/vmemo-proto/README.md
@@ -1,0 +1,79 @@
+# vmemo-proto (Voice Memos → Transcribe → Rename → Export)
+
+A lightweight, local-first prototype that **detects new Apple Voice Memos on macOS**, pulls the **built‑in transcript** (if present), falls back to **Whisper.cpp** if missing, **generates a clean title**, and **exports a renamed copy** with the transcript next to it.
+
+**Why copy instead of renaming inside the app?** Voice Memos tracks recordings via internal IDs and a database. Renaming files in the app container can cause link breakage. This tool **keeps the app’s library intact** and creates a **clean, portable export** for your automations. (Optional: a best‑effort AppleScript can also try to rename the item in the app UI — off by default.)
+
+## What you get
+- ✅ Watches the iCloud‑synced Voice Memos folder
+- ✅ Extracts Apple’s transcript from the M4A (`trsp` atom) when available
+- ✅ If no transcript is found, **optionally** runs Whisper.cpp (if installed) to transcribe locally
+- ✅ Generates a slugified, short title (configurable) and exports:
+  - `/root/VoiceMemos/Processed/YYYY-MM-DD/<title>.m4a`
+  - `/root/VoiceMemos/Processed/YYYY-MM-DD/<title>.txt` (plain transcript)
+  - `/root/VoiceMemos/Processed/YYYY-MM-DD/<title>.json` (metadata)
+- ✅ LaunchAgent so it runs at login
+- ✅ MCP snippet for Claude Desktop to add an AppleScript server (for optional UI automation)
+- ✅ Zero Python deps (standard library only)
+
+## Requirements
+- macOS with Voice Memos syncing via iCloud (default)
+- Python 3.10+ (preinstalled on recent macOS)
+- (Optional) **Whisper.cpp** via Homebrew for on-device fallback transcription
+  ```bash
+  brew install whisper-cpp ffmpeg
+  # download a model, e.g. base
+  curl -L -o ~/Library/Application\ Support/vmemo/models/ggml-base.en.bin \
+       https://ggml.ggerganov.com/ggml-model-whisper-base.en-q5_1.bin
+  ```
+
+## Install
+```bash
+chmod +x ./install.sh
+./install.sh
+```
+
+This will:
+- put files under `~/Library/Application Support/vmemo`
+- create `~/VoiceMemos/Processed` if needed
+- load the LaunchAgent so it starts watching immediately
+
+## Uninstall
+```bash
+./uninstall.sh
+```
+
+## Configuration: `config.yaml`
+```yaml
+recordings_dir: "~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings"
+out_dir: "~/VoiceMemos/Processed"
+rename_in_app: false                 # try to rename inside Voice Memos UI (fragile)
+title_words: 8                       # max words in generated title
+whispercpp_path: "whisper-cpp"       # CLI name or absolute path
+whisper_model: "~/Library/Application Support/vmemo/models/ggml-base.en.bin"
+language: "en"
+```
+
+## MCP (Claude Desktop) – optional AppleScript control
+Add an AppleScript MCP server so Claude can run small AppleScripts like “rename latest Voice Memo to X”. Put this snippet in your Claude client MCP config (see docs):
+
+```json
+{
+  "mcpServers": {
+    "applescript_execute": {
+      "command": "npx",
+      "args": ["@peakmojo/applescript-mcp@latest"]
+    }
+  }
+}
+```
+
+Then you can ask Claude to run AppleScript like:
+> rename latest voice memo to “Standup Sync – blockers”
+
+(You may still need to grant **Accessibility** permissions for automation to control Voice Memos.)
+
+## Notes & caveats
+- Voice Memos’ internal library is not officially scriptable and can change. This tool purposely **does not** mutate the library. It **exports clean copies** for downstream workflows.
+- The included AppleScript (`vmemo_rename.applescript`) tries to rename the topmost item in the Voice Memos list — it works on many setups but is **brittle** across OS updates. Keep it off unless you need it.
+- You can run the agent manually: `python3 vmemo_agent.py --once` to process pending items once and exit.

--- a/vmemo-proto/com.nabi.voicememos.agent.plist
+++ b/vmemo-proto/com.nabi.voicememos.agent.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.nabi.voicememos.agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/root/Library/Application Support/vmemo/vmemo_agent.py</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/vmemo_agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/vmemo_agent.err</string>
+</dict>
+</plist>

--- a/vmemo-proto/config.yaml
+++ b/vmemo-proto/config.yaml
@@ -1,0 +1,7 @@
+recordings_dir: "~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings"
+out_dir: "~/VoiceMemos/Processed"
+rename_in_app: false
+title_words: 8
+whispercpp_path: "whisper-cpp"
+whisper_model: "~/Library/Application Support/vmemo/models/ggml-base.en.bin"
+language: "en"

--- a/vmemo-proto/install.sh
+++ b/vmemo-proto/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_SUPPORT="$HOME/Library/Application Support/vmemo"
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+OUT_DIR="$HOME/VoiceMemos/Processed"
+
+mkdir -p "$APP_SUPPORT" "$OUT_DIR" "$LAUNCH_AGENTS"
+
+# Copy payload
+cp -f vmemo_agent.py "$APP_SUPPORT/"
+cp -f vmemo_rename.applescript "$APP_SUPPORT/"
+cp -f config.yaml "$APP_SUPPORT/"
+cp -f com.nabi.voicememos.agent.plist "$LAUNCH_AGENTS/"
+
+# Ensure readable
+chmod 644 "$APP_SUPPORT/vmemo_agent.py" "$APP_SUPPORT/vmemo_rename.applescript" "$APP_SUPPORT/config.yaml" "$LAUNCH_AGENTS/com.nabi.voicememos.agent.plist"
+
+# Load agent
+launchctl unload "$LAUNCH_AGENTS/com.nabi.voicememos.agent.plist" &>/dev/null || true
+launchctl load -w "$LAUNCH_AGENTS/com.nabi.voicememos.agent.plist"
+
+echo "✅ Installed. Logs: log stream --predicate 'process == \"vmemo_agent\"' --style compact"

--- a/vmemo-proto/uninstall.sh
+++ b/vmemo-proto/uninstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+APP_SUPPORT="$HOME/Library/Application Support/vmemo"
+
+launchctl unload "$LAUNCH_AGENTS/com.nabi.voicememos.agent.plist" &>/dev/null || true
+rm -f "$LAUNCH_AGENTS/com.nabi.voicememos.agent.plist"
+
+rm -rf "$APP_SUPPORT"
+
+echo "✅ Uninstalled."

--- a/vmemo-proto/vmemo_agent.py
+++ b/vmemo-proto/vmemo_agent.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+vmemo_agent.py — local-first Voice Memos watcher.
+- Watches the Voice Memos Group Container for new .m4a files
+- Extracts Apple's transcript from the "trsp" atom when present
+- If missing, optionally transcribes with whisper-cpp (if installed)
+- Generates a compact title, copies audio + writes transcript/metadata
+- (Optional) Best-effort AppleScript rename inside the app UI
+"""
+
+import os, sys, time, json, shutil, subprocess, re, struct, datetime, pathlib, hashlib
+from typing import Any, BinaryIO, Dict, List, Tuple
+
+HOME = pathlib.Path.home()
+APP_DIR = HOME / "Library" / "Application Support" / "vmemo"
+STATE_PATH = APP_DIR / "state.json"
+CONF_PATH = APP_DIR / "config.yaml"
+
+DEFAULTS = {
+    "recordings_dir": str(HOME / "Library" / "Group Containers" / "group.com.apple.VoiceMemos.shared" / "Recordings"),
+    "out_dir": str(HOME / "VoiceMemos" / "Processed"),
+    "rename_in_app": False,
+    "title_words": 8,
+    "whispercpp_path": "whisper-cpp",
+    "whisper_model": str(HOME / "Library" / "Application Support" / "vmemo" / "models" / "ggml-base.en.bin"),
+    "language": "en",
+}
+
+def load_config() -> Dict[str, Any]:
+    d = DEFAULTS.copy()
+    try:
+        import yaml  # If user has PyYAML, great; otherwise parse trivially
+        with open(CONF_PATH, "r") as f:
+            cfg = yaml.safe_load(f) or {}
+        d.update(cfg or {})
+    except Exception:
+        # Super-simple parser: key: value
+        if CONF_PATH.exists():
+            for line in CONF_PATH.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or ":" not in line:
+                    continue
+                k, v = line.split(":", 1)
+                d[k.strip()] = v.strip().strip('"').strip("'")
+    # Expand ~
+    for k in ("recordings_dir", "out_dir", "whispercpp_path", "whisper_model"):
+        if k in d and isinstance(d[k], str):
+            d[k] = os.path.expanduser(d[k])
+    return d
+
+def load_state() -> Dict[str, Any]:
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception:
+        return {"processed": {}}
+
+def save_state(state: Dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(json.dumps(state, indent=2))
+
+def file_signature(p: pathlib.Path) -> str:
+    st = p.stat()
+    h = hashlib.sha1()
+    h.update(str(p).encode())
+    h.update(str(st.st_size).encode())
+    h.update(str(int(st.st_mtime)).encode())
+    return h.hexdigest()
+
+def find_new_recordings(cfg: Dict[str, Any], state: Dict[str, Any]) -> List[Tuple[pathlib.Path, str]]:
+    root = pathlib.Path(cfg["recordings_dir"]).expanduser()
+    if not root.exists():
+        return []
+    files = sorted(root.glob("*.m4a"), key=lambda p: p.stat().st_mtime, reverse=True)
+    new: List[Tuple[pathlib.Path, str]] = []
+    for p in files:
+        sig = file_signature(p)
+        if sig not in state["processed"]:
+            new.append((p, sig))
+    return new
+
+def wait_until_stable(p: pathlib.Path, timeout: int = 30, interval: float = 0.5) -> bool:
+    deadline = time.time() + timeout
+    last = -1
+    while time.time() < deadline:
+        sz = p.stat().st_size
+        if sz == last and sz > 0:
+            return True
+        last = sz
+        time.sleep(interval)
+    return False
+
+# ---- MP4 atom scanning to find "trsp" ----
+
+def read_atom(f: BinaryIO) -> Tuple[int | None, str | None, int | None]:
+    header = f.read(8)
+    if len(header) < 8:
+        return None, None, None
+    size, atype = struct.unpack(">I4s", header)
+    if size == 1:  # 64-bit size
+        largesize = f.read(8)
+        if len(largesize) < 8:
+            return None, None, None
+        (size64,) = struct.unpack(">Q", largesize)
+        hlen = 16
+        return size64, atype.decode("latin-1"), hlen
+    else:
+        return size, atype.decode("latin-1"), 8
+
+def extract_trsp_json(path: pathlib.Path) -> str | None:
+    with path.open("rb") as f:
+        filesize = path.stat().st_size
+        pos = 0
+        while pos < filesize:
+            r = read_atom(f)
+            if r[0] is None: break
+            size, atype, hlen = r
+            data_len = int(size) - hlen
+            if data_len < 0: break
+            if atype == "trsp":
+                data = f.read(data_len)
+                # Sometimes trailing zeros; strip
+                try:
+                    # Find first '{' and last '}' to bound JSON
+                    s = data.decode("utf-8", errors="ignore")
+                    start = s.find("{")
+                    end = s.rfind("}")
+                    if start != -1 and end != -1 and end > start:
+                        return s[start:end+1]
+                except Exception:
+                    pass
+                return None
+            else:
+                f.seek(data_len, 1)
+            pos = f.tell()
+    return None
+
+def flatten_trsp_text(trsp_json: str) -> str:
+    try:
+        obj = json.loads(trsp_json)
+        parts = obj.get("attributedString", [])
+        out = []
+        for item in parts:
+            if isinstance(item, str):
+                out.append(item.strip())
+        text = " ".join(out)
+        # collapse whitespace
+        text = re.sub(r"\s+", " ", text).strip()
+        return text
+    except Exception:
+        return ""
+
+def transcribe_with_whisper_cpp(cfg: Dict[str, Any], path: pathlib.Path) -> str | None:
+    exe = cfg.get("whispercpp_path", "whisper-cpp")
+    model = cfg.get("whisper_model")
+    lang = cfg.get("language", "en")
+    if not shutil.which(exe):
+        return None
+    if not model or not pathlib.Path(model).expanduser().exists():
+        return None
+    # Use ffmpeg to pipe 16kHz mono WAV to whisper-cpp for better reliability
+    cmd = [
+        "bash", "-lc",
+        f"""ffmpeg -loglevel error -y -i \"{path}\" -ar 16000 -ac 1 -f wav - | """
+        f"""GGML_METAL_PATH_RESOURCES=\"$(brew --prefix whisper-cpp 2>/dev/null)/share/whisper-cpp\" """
+        f"""{exe} --model \"{model}\" --language {lang} --output-txt --output-file - -"""
+    ]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=60*15)
+        if res.returncode == 0 and res.stdout:
+            # whisper-cpp prints transcript to stdout with timestamps; strip if needed
+            txt = res.stdout
+            # remove timestamps like [00:00:00.000 --> 00:00:01.000]
+            txt = re.sub(r"\[\d{2}:\d{2}:\d{2}\.\d{3}\s+-->\s+\d{2}:\d{2}:\d{2}\.\d{3}\]\s*", "", txt)
+            txt = re.sub(r"\s+", " ", txt).strip()
+            return txt
+    except Exception as e:
+        pass
+    return None
+
+def slugify_title(s: str, max_words: int = 8) -> str:
+    if not s:
+        return ""
+    # Keep alphanumerics and spaces
+    s = re.sub(r"[^A-Za-z0-9' ]+", " ", s)
+    # collapse whitespace
+    s = re.sub(r"\s+", " ", s).strip()
+    # split and cap words
+    words = s.split()[:max_words]
+    title = " ".join(words)
+    # Capitalize first letter
+    if title:
+        title = title[0].upper() + title[1:]
+    # file-safe slug
+    slug = re.sub(r"[^\w\- ]", "", title).strip()
+    slug = re.sub(r"\s+", " ", slug)
+    return slug
+
+def export_artifacts(
+    cfg: Dict[str, Any],
+    src: pathlib.Path,
+    title: str,
+    transcript_txt: str,
+    trsp_json: str | None,
+) -> Tuple[pathlib.Path, pathlib.Path, pathlib.Path]:
+    out_root = pathlib.Path(cfg["out_dir"]).expanduser()
+    date_folder = datetime.datetime.fromtimestamp(src.stat().st_mtime).strftime("%Y-%m-%d")
+    folder = out_root / date_folder
+    folder.mkdir(parents=True, exist_ok=True)
+
+    # Prefix with timestamp to avoid collisions
+    ts = datetime.datetime.fromtimestamp(src.stat().st_mtime).strftime("%Y%m%d-%H%M%S")
+    base = f"{ts} — {title or 'Untitled'}".strip()
+    base = re.sub(r"[/\\:]+", "—", base)  # safety
+
+    audio_dst = folder / f"{base}.m4a"
+    txt_dst = folder / f"{base}.txt"
+    json_dst = folder / f"{base}.json"
+
+    if not audio_dst.exists():
+        shutil.copy2(src, audio_dst)
+    txt_dst.write_text((transcript_txt or "").strip() + "\n")
+    meta = {
+        "source_path": str(src),
+        "exported_path": str(audio_dst),
+        "created": ts,
+        "title": title,
+        "transcript_chars": len(transcript_txt or ""),
+        "has_native_trsp": bool(trsp_json),
+    }
+    if trsp_json:
+        meta["native_trsp"] = json.loads(trsp_json)
+    json_dst.write_text(json.dumps(meta, indent=2))
+    return audio_dst, txt_dst, json_dst
+
+def attempt_in_app_rename(new_title: str) -> bool:
+    scpt = APP_DIR / "vmemo_rename.applescript"
+    if not scpt.exists():
+        return False
+    try:
+        subprocess.run(["osascript", str(scpt), new_title], check=False)
+        return True
+    except Exception:
+        return False
+
+def process_one(cfg: Dict[str, Any], path: pathlib.Path) -> Tuple[bool, str]:
+    # Wait until file stops growing
+    if not wait_until_stable(path):
+        return False, "file-not-stable"
+
+    trsp_json = extract_trsp_json(path)
+    if trsp_json:
+        transcript_txt = flatten_trsp_text(trsp_json)
+    else:
+        transcript_txt = None
+
+    if not transcript_txt:
+        # fallback to whisper-cpp if available
+        transcript_txt = transcribe_with_whisper_cpp(cfg, path)
+
+    # Title heuristic
+    title = slugify_title(transcript_txt or "", cfg.get("title_words", 8))
+    if not title:
+        # Use date + duration fallback (no duration without parsing m4a deeper, use size)
+        title = "Voice Memo"
+
+    # Export artifacts
+    audio_dst, txt_dst, json_dst = export_artifacts(cfg, path, title, transcript_txt or "", trsp_json)
+
+    # Optional rename in app
+    if cfg.get("rename_in_app"):
+        attempt_in_app_rename(title)
+
+    return True, str(audio_dst)
+
+def main() -> None:
+    cfg = load_config()
+    state = load_state()
+
+    # One-shot mode (for CI/testing)
+    if "--once" in sys.argv:
+        new = find_new_recordings(cfg, state)
+        for p, sig in new:
+            ok, info = process_one(cfg, p)
+            if ok:
+                state["processed"][sig] = {"ts": int(time.time()), "path": str(p)}
+                save_state(state)
+                print(f"Processed: {p} -> {info}")
+        return
+
+    print("vmemo_agent starting...")
+    while True:
+        try:
+            new = find_new_recordings(cfg, state)
+            for p, sig in new:
+                ok, info = process_one(cfg, p)
+                if ok:
+                    state["processed"][sig] = {"ts": int(time.time()), "path": str(p)}
+                    save_state(state)
+                    print(f"Processed: {p} -> {info}")
+            time.sleep(5)
+        except Exception as e:
+            print("Error:", e, file=sys.stderr)
+            time.sleep(5)
+
+if __name__ == "__main__":
+    main()

--- a/vmemo-proto/vmemo_rename.applescript
+++ b/vmemo-proto/vmemo_rename.applescript
@@ -1,0 +1,52 @@
+-- vmemo_rename.applescript
+-- Best-effort GUI scripting to rename the topmost Voice Memos item.
+-- Usage: osascript vmemo_rename.applescript "New Title"
+
+on run argv
+  if (count of argv) is 0 then
+    display dialog "Usage: osascript vmemo_rename.applescript \"New Title\"" buttons {"OK"} default button "OK"
+    return
+  end if
+  set newTitle to item 1 of argv
+
+  tell application "Voice Memos" to activate
+  delay 0.5
+
+  tell application "System Events"
+    if not (exists process "Voice Memos") then
+      display dialog "Voice Memos not running." buttons {"OK"} default button "OK"
+      return
+    end if
+
+    tell process "Voice Memos"
+      set frontmost to true
+      try
+        -- Attempt to select first row in the left outline (All Recordings)
+        -- UI hierarchies change often; this targets typical structure.
+        tell window 1
+          tell splitter group 1
+            tell group 1
+              tell scroll area 1
+                tell outline 1
+                  if (count of rows) is 0 then error "No recordings found."
+                  select row 1
+                end tell
+              end tell
+            end tell
+          end tell
+        end tell
+
+        delay 0.1
+        -- Start inline rename: Return often enters "edit title" on selection.
+        key code 36
+        delay 0.05
+        -- Select all, type title, press Return
+        keystroke "a" using {command down}
+        keystroke newTitle
+        key code 36
+      on error errMsg number errNum
+        display dialog "Rename failed: " & errMsg buttons {"OK"} default button "OK"
+      end try
+    end tell
+  end tell
+end run


### PR DESCRIPTION
## Summary
- add vmemo-proto, a lightweight Voice Memos watcher and exporter for macOS
- include install/uninstall scripts, LaunchAgent plist, and optional AppleScript renamer
- provide ready-to-use zip bundle for distribution
- remove bundled zip artifact and ignore it going forward

## Testing
- `pre-commit run --files .gitignore`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68916065eac88323a41f5ba23e3a96e0